### PR TITLE
chore: format + clippy clean; update AGENTS.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Test
         run: cargo test --workspace --all-features --locked
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,9 @@
 - Use Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `build:`, `ci:`, `chore:`.
 - PRs: include summary, rationale, linked issues, and usage notes; attach logs or screenshots when UX changes.
 - Keep changes scoped; update docs/examples when interfaces or flags change.
+- Before opening a PR: ensure formatting and linting are clean.
+  - Format: `cargo fmt --all` (no diffs).
+  - Lint: `cargo clippy --all-targets --all-features -D warnings` (zero warnings).
 
 ## Plan-Driven Workflow
 - Always work from `PLAN.md` as the single source of truth.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 - Start a session: `cargo run -p par-cli -- start demo --path .` (belljar will provision compose if it finds `.belljar/compose/*.yml` or `docker-compose.yml|yaml`).
 - Tests (unit + integration): `cargo test`.
 - Docker-gated tests: `DOCKER_TESTS=1 cargo test` (requires Docker + Compose v2).
-- Lint: `cargo clippy --all-targets --all-features -D warnings`.
+- Lint: `cargo clippy --all-targets --all-features -- -D warnings`.
 - Format: `cargo fmt --all`.
 
 ## Coding Style & Naming Conventions

--- a/app/tests/cli_compose.rs
+++ b/app/tests/cli_compose.rs
@@ -16,6 +16,9 @@ fn init_git_repo_with_compose() -> (tempfile::TempDir, PathBuf) {
         .status()
         .unwrap()
         .success());
+    // set identity for commit on CI
+    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.email","ci@example.com"]).status().unwrap().success());
+    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.name","CI"]).status().unwrap().success());
     fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")
         .arg("-C")

--- a/app/tests/cli_compose.rs
+++ b/app/tests/cli_compose.rs
@@ -17,8 +17,20 @@ fn init_git_repo_with_compose() -> (tempfile::TempDir, PathBuf) {
         .unwrap()
         .success());
     // set identity for commit on CI
-    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.email","ci@example.com"]).status().unwrap().success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.name","CI"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.email", "ci@example.com"])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.name", "CI"])
+        .status()
+        .unwrap()
+        .success());
     fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")
         .arg("-C")

--- a/app/tests/cli_compose.rs
+++ b/app/tests/cli_compose.rs
@@ -2,17 +2,35 @@ use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
 
 fn init_git_repo_with_compose() -> (tempfile::TempDir, PathBuf) {
     let td = TempDir::new().unwrap();
     let repo = td.path();
-    assert!(Command::new("git").arg("-C").arg(repo).arg("init").status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .arg("init")
+        .status()
+        .unwrap()
+        .success());
     fs::write(repo.join("README.md"), "init\n").unwrap();
-    assert!(Command::new("git").arg("-C").arg(repo).args(["add", "."]).status().unwrap().success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["commit", "-m", "init"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["add", "."])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["commit", "-m", "init"])
+        .status()
+        .unwrap()
+        .success());
     // add compose file
     let bj = repo.join(".belljar/compose");
     fs::create_dir_all(&bj).unwrap();
@@ -21,7 +39,7 @@ fn init_git_repo_with_compose() -> (tempfile::TempDir, PathBuf) {
     (td, cf)
 }
 
-fn prepend_path(dir: &PathBuf) -> String {
+fn prepend_path(dir: &Path) -> String {
     let old = std::env::var("PATH").unwrap_or_default();
     format!("{}:{}", dir.display(), old)
 }
@@ -30,7 +48,10 @@ fn make_docker_shim_logging() -> (TempDir, PathBuf) {
     let dir = TempDir::new().unwrap();
     let log = dir.path().join("docker.log");
     let shim = dir.path().join("docker");
-    let script = format!("#!/usr/bin/env bash\necho \"$@\" >> {}\nexit 0\n", log.display());
+    let script = format!(
+        "#!/usr/bin/env bash\necho \"$@\" >> {}\nexit 0\n",
+        log.display()
+    );
     fs::write(&shim, script).unwrap();
     let mut perm = fs::metadata(&shim).unwrap().permissions();
     perm.set_mode(0o755);
@@ -44,10 +65,12 @@ fn start_with_compose_runs_up() {
     let (repo_td, cf) = init_git_repo_with_compose();
     let (shim_dir, log) = make_docker_shim_logging();
 
-    Command::cargo_bin("belljar").unwrap()
-        .args(["start", "s1", "--path"]).arg(repo_td.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["start", "s1", "--path"])
+        .arg(repo_td.path())
         .env("BELLJAR_DATA_DIR", data.path())
-        .env("PATH", prepend_path(&shim_dir.path().to_path_buf()))
+        .env("PATH", prepend_path(shim_dir.path()))
         .assert()
         .success()
         .stdout(predicate::str::contains("[compose up]"));
@@ -64,12 +87,20 @@ fn checkout_with_compose_runs_up() {
     let (repo_td, cf) = init_git_repo_with_compose();
     let (shim_dir, log) = make_docker_shim_logging();
     // create branch to checkout
-    assert!(Command::new("git").arg("-C").arg(repo_td.path()).args(["checkout", "-b", "fx"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo_td.path())
+        .args(["checkout", "-b", "fx"])
+        .status()
+        .unwrap()
+        .success());
 
-    Command::cargo_bin("belljar").unwrap()
-        .args(["checkout", "fx", "--path"]).arg(repo_td.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["checkout", "fx", "--path"])
+        .arg(repo_td.path())
         .env("BELLJAR_DATA_DIR", data.path())
-        .env("PATH", prepend_path(&shim_dir.path().to_path_buf()))
+        .env("PATH", prepend_path(shim_dir.path()))
         .assert()
         .success()
         .stdout(predicate::str::contains("[compose up]"));
@@ -85,16 +116,20 @@ fn rm_session_triggers_down() {
     let (repo_td, _cf) = init_git_repo_with_compose();
     let (shim_dir, log) = make_docker_shim_logging();
 
-    Command::cargo_bin("belljar").unwrap()
-        .args(["start", "s1", "--path"]).arg(repo_td.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["start", "s1", "--path"])
+        .arg(repo_td.path())
         .env("BELLJAR_DATA_DIR", data.path())
-        .env("PATH", prepend_path(&shim_dir.path().to_path_buf()))
-        .assert().success();
+        .env("PATH", prepend_path(shim_dir.path()))
+        .assert()
+        .success();
 
-    Command::cargo_bin("belljar").unwrap()
-        .args(["rm", "s1"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["rm", "s1"])
         .env("BELLJAR_DATA_DIR", data.path())
-        .env("PATH", prepend_path(&shim_dir.path().to_path_buf()))
+        .env("PATH", prepend_path(shim_dir.path()))
         .assert()
         .success()
         .stdout(predicate::str::contains("removed s1"));
@@ -110,23 +145,29 @@ fn rm_all_triggers_down_for_all() {
     let (shim_dir, log) = make_docker_shim_logging();
 
     for s in ["a", "b"] {
-        Command::cargo_bin("belljar").unwrap()
-            .args(["start", s, "--path"]).arg(repo_td.path())
+        Command::cargo_bin("belljar")
+            .unwrap()
+            .args(["start", s, "--path"])
+            .arg(repo_td.path())
             .env("BELLJAR_DATA_DIR", data.path())
-            .env("PATH", prepend_path(&shim_dir.path().to_path_buf()))
-            .assert().success();
+            .env("PATH", prepend_path(shim_dir.path()))
+            .assert()
+            .success();
     }
 
-    Command::cargo_bin("belljar").unwrap()
-        .args(["rm", "all"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["rm", "all"])
         .env("BELLJAR_DATA_DIR", data.path())
-        .env("PATH", prepend_path(&shim_dir.path().to_path_buf()))
+        .env("PATH", prepend_path(shim_dir.path()))
         .assert()
         .success()
         .stdout(predicate::str::contains("removed a").and(predicate::str::contains("removed b")));
 
     let logged = fs::read_to_string(&log).unwrap();
     let count = logged.matches(" down -v").count();
-    assert!(count >= 2, "expected at least two down invocations, got {} in: {}", count, logged);
+    assert!(
+        count >= 2,
+        "expected at least two down invocations, got {count} in: {logged}"
+    );
 }
-

--- a/app/tests/cli_cov.rs
+++ b/app/tests/cli_cov.rs
@@ -6,22 +6,42 @@ use tempfile::TempDir;
 fn init_git_repo() -> tempfile::TempDir {
     let td = TempDir::new().unwrap();
     let repo = td.path();
-    assert!(Command::new("git").arg("-C").arg(repo).arg("init").status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .arg("init")
+        .status()
+        .unwrap()
+        .success());
     std::fs::write(repo.join("README.md"), "init\n").unwrap();
-    assert!(Command::new("git").arg("-C").arg(repo).args(["add", "."]).status().unwrap().success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["commit", "-m", "init"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["add", "."])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["commit", "-m", "init"])
+        .status()
+        .unwrap()
+        .success());
     td
 }
 
 #[test]
 fn version_and_help() {
-    Command::cargo_bin("belljar").unwrap()
+    Command::cargo_bin("belljar")
+        .unwrap()
         .arg("--version")
         .assert()
         .success()
         .stdout(predicate::str::contains("belljar"));
 
-    Command::cargo_bin("belljar").unwrap()
+    Command::cargo_bin("belljar")
+        .unwrap()
         .arg("--help")
         .assert()
         .success()
@@ -33,20 +53,24 @@ fn start_ls_rm_cycle() {
     let data = TempDir::new().unwrap();
     let repo = init_git_repo();
 
-    Command::cargo_bin("belljar").unwrap()
-        .args(["start", "s1", "--path"]).arg(repo.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["start", "s1", "--path"])
+        .arg(repo.path())
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
         .success();
 
-    Command::cargo_bin("belljar").unwrap()
+    Command::cargo_bin("belljar")
+        .unwrap()
         .arg("ls")
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
         .success()
         .stdout(predicate::str::contains("s1\t"));
 
-    Command::cargo_bin("belljar").unwrap()
+    Command::cargo_bin("belljar")
+        .unwrap()
         .args(["rm", "s1"])
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
@@ -58,13 +82,20 @@ fn start_ls_rm_cycle() {
 fn checkout_flow() {
     let data = TempDir::new().unwrap();
     let repo = init_git_repo();
-    assert!(Command::new("git").arg("-C").arg(repo.path()).args(["checkout", "-b", "fx"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo.path())
+        .args(["checkout", "-b", "fx"])
+        .status()
+        .unwrap()
+        .success());
 
-    Command::cargo_bin("belljar").unwrap()
-        .args(["checkout", "fx", "--path"]).arg(repo.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["checkout", "fx", "--path"])
+        .arg(repo.path())
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
         .success()
         .stdout(predicate::str::contains("checked out: fx -> fx"));
 }
-

--- a/app/tests/cli_cov.rs
+++ b/app/tests/cli_cov.rs
@@ -13,8 +13,20 @@ fn init_git_repo() -> tempfile::TempDir {
         .status()
         .unwrap()
         .success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.email","ci@example.com"]).status().unwrap().success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.name","CI"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.email", "ci@example.com"])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.name", "CI"])
+        .status()
+        .unwrap()
+        .success());
     std::fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")
         .arg("-C")

--- a/app/tests/cli_cov.rs
+++ b/app/tests/cli_cov.rs
@@ -13,6 +13,8 @@ fn init_git_repo() -> tempfile::TempDir {
         .status()
         .unwrap()
         .success());
+    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.email","ci@example.com"]).status().unwrap().success());
+    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.name","CI"]).status().unwrap().success());
     std::fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")
         .arg("-C")

--- a/app/tests/cli_error_paths.rs
+++ b/app/tests/cli_error_paths.rs
@@ -5,8 +5,9 @@ use tempfile::TempDir;
 
 #[test]
 fn start_invalid_path_fails() {
-    Command::cargo_bin("belljar").unwrap()
-        .args(["start", "s1", "--path", "/definitely/not/here"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["start", "s1", "--path", "/definitely/not/here"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("path does not exist"));
@@ -17,14 +18,18 @@ fn open_without_tmux_prints_fallback() {
     let data = TempDir::new().unwrap();
     let repo = TempDir::new().unwrap();
     // create session directly via CLI
-    Command::cargo_bin("belljar").unwrap()
-        .args(["start", "s1", "--path"]).arg(repo.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["start", "s1", "--path"])
+        .arg(repo.path())
         .env("BELLJAR_DATA_DIR", data.path())
-        .assert().success();
+        .assert()
+        .success();
 
     // clear PATH so tmux is missing
-    Command::cargo_bin("belljar").unwrap()
-        .args(["open", "s1"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["open", "s1"])
         .env("BELLJAR_DATA_DIR", data.path())
         .env("PATH", "/nonexistent")
         .assert()
@@ -38,13 +43,17 @@ fn send_all_with_tmux_missing_reports_errors_but_succeeds() {
     let repo = TempDir::new().unwrap();
     // create two sessions
     for s in ["a", "b"] {
-        Command::cargo_bin("belljar").unwrap()
-            .args(["start", s, "--path"]).arg(repo.path())
+        Command::cargo_bin("belljar")
+            .unwrap()
+            .args(["start", s, "--path"])
+            .arg(repo.path())
             .env("BELLJAR_DATA_DIR", data.path())
-            .assert().success();
+            .assert()
+            .success();
     }
-    Command::cargo_bin("belljar").unwrap()
-        .args(["send", "all", "echo", "hi"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["send", "all", "echo", "hi"])
         .env("BELLJAR_DATA_DIR", data.path())
         .env("PATH", "/nonexistent")
         .assert()
@@ -54,7 +63,8 @@ fn send_all_with_tmux_missing_reports_errors_but_succeeds() {
 #[test]
 fn control_center_no_sessions() {
     let data = TempDir::new().unwrap();
-    Command::cargo_bin("belljar").unwrap()
+    Command::cargo_bin("belljar")
+        .unwrap()
         .arg("control-center")
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()

--- a/app/tests/cli_fail_create.rs
+++ b/app/tests/cli_fail_create.rs
@@ -1,12 +1,12 @@
-use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use predicates::prelude::*;
 
 #[test]
 fn start_fails_when_data_dir_unwritable() {
     // On typical systems, writing under / is not allowed for normal users.
-    Command::cargo_bin("belljar").unwrap()
-        .args(["start", "s1"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["start", "s1"])
         .env("BELLJAR_DATA_DIR", "/")
         .assert()
         .failure()

--- a/app/tests/cli_more.rs
+++ b/app/tests/cli_more.rs
@@ -46,6 +46,8 @@ fn init_git_repo() -> tempfile::TempDir {
         .status()
         .unwrap()
         .success());
+    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.email","ci@example.com"]).status().unwrap().success());
+    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.name","CI"]).status().unwrap().success());
     fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")
         .arg("-C")

--- a/app/tests/cli_more.rs
+++ b/app/tests/cli_more.rs
@@ -46,8 +46,20 @@ fn init_git_repo() -> tempfile::TempDir {
         .status()
         .unwrap()
         .success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.email","ci@example.com"]).status().unwrap().success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.name","CI"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.email", "ci@example.com"])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.name", "CI"])
+        .status()
+        .unwrap()
+        .success());
     fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")
         .arg("-C")

--- a/app/tests/cli_more.rs
+++ b/app/tests/cli_more.rs
@@ -2,11 +2,11 @@ use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-fn prepend_path(dir: &PathBuf) -> String {
+fn prepend_path(dir: &Path) -> String {
     let old = std::env::var("PATH").unwrap_or_default();
     format!("{}:{}", dir.display(), old)
 }
@@ -14,7 +14,8 @@ fn prepend_path(dir: &PathBuf) -> String {
 #[test]
 fn ls_no_sessions() {
     let data = TempDir::new().unwrap();
-    Command::cargo_bin("belljar").unwrap()
+    Command::cargo_bin("belljar")
+        .unwrap()
         .arg("ls")
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
@@ -26,8 +27,7 @@ fn make_tmux_shim(has_session_exit: i32, attach_exit: i32, send_exit: i32) -> Te
     let dir = TempDir::new().unwrap();
     let shim = dir.path().join("tmux");
     let script = format!(
-        "#!/usr/bin/env bash\nif [ \"$1\" = has-session ]; then exit {}; fi\nif [ \"$1\" = attach-session ]; then exit {}; fi\nif [ \"$1\" = send-keys ]; then exit {}; fi\nexit 0\n",
-        has_session_exit, attach_exit, send_exit
+        "#!/usr/bin/env bash\nif [ \"$1\" = has-session ]; then exit {has_session_exit}; fi\nif [ \"$1\" = attach-session ]; then exit {attach_exit}; fi\nif [ \"$1\" = send-keys ]; then exit {send_exit}; fi\nexit 0\n"
     );
     fs::write(&shim, script).unwrap();
     let mut perm = fs::metadata(&shim).unwrap().permissions();
@@ -39,10 +39,28 @@ fn make_tmux_shim(has_session_exit: i32, attach_exit: i32, send_exit: i32) -> Te
 fn init_git_repo() -> tempfile::TempDir {
     let td = TempDir::new().unwrap();
     let repo = td.path();
-    assert!(Command::new("git").arg("-C").arg(repo).arg("init").status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .arg("init")
+        .status()
+        .unwrap()
+        .success());
     fs::write(repo.join("README.md"), "init\n").unwrap();
-    assert!(Command::new("git").arg("-C").arg(repo).args(["add", "."]).status().unwrap().success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["commit", "-m", "init"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["add", "."])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["commit", "-m", "init"])
+        .status()
+        .unwrap()
+        .success());
     td
 }
 
@@ -51,17 +69,21 @@ fn send_error_path_reports_but_exits_success() {
     let data = TempDir::new().unwrap();
     let repo = init_git_repo();
     // create session
-    Command::cargo_bin("belljar").unwrap()
-        .args(["start", "s1", "--path"]).arg(repo.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["start", "s1", "--path"])
+        .arg(repo.path())
         .env("BELLJAR_DATA_DIR", data.path())
-        .assert().success();
+        .assert()
+        .success();
 
     // tmux shim: has-session ok, attach ok, send-keys fails
     let shim_dir = make_tmux_shim(0, 0, 1);
-    Command::cargo_bin("belljar").unwrap()
-        .args(["send", "s1", "echo", "hi"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["send", "s1", "echo", "hi"])
         .env("BELLJAR_DATA_DIR", data.path())
-        .env("PATH", prepend_path(&shim_dir.path().to_path_buf()))
+        .env("PATH", prepend_path(shim_dir.path()))
         .assert()
         .success()
         .stderr(predicate::str::contains("send failed"));
@@ -71,17 +93,21 @@ fn send_error_path_reports_but_exits_success() {
 fn open_attach_failure_is_reported() {
     let data = TempDir::new().unwrap();
     let repo = init_git_repo();
-    Command::cargo_bin("belljar").unwrap()
-        .args(["start", "s1", "--path"]).arg(repo.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["start", "s1", "--path"])
+        .arg(repo.path())
         .env("BELLJAR_DATA_DIR", data.path())
-        .assert().success();
+        .assert()
+        .success();
 
     // tmux shim: has-session ok; attach fails
     let shim_dir = make_tmux_shim(0, 1, 0);
-    Command::cargo_bin("belljar").unwrap()
-        .args(["open", "s1"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["open", "s1"])
         .env("BELLJAR_DATA_DIR", data.path())
-        .env("PATH", prepend_path(&shim_dir.path().to_path_buf()))
+        .env("PATH", prepend_path(shim_dir.path()))
         .assert()
         .success()
         .stderr(predicate::str::contains("failed to attach"));
@@ -92,17 +118,21 @@ fn control_center_attach_failure_reported() {
     let data = TempDir::new().unwrap();
     let repo = init_git_repo();
     for s in ["a", "b"] {
-        Command::cargo_bin("belljar").unwrap()
-            .args(["start", s, "--path"]).arg(repo.path())
+        Command::cargo_bin("belljar")
+            .unwrap()
+            .args(["start", s, "--path"])
+            .arg(repo.path())
             .env("BELLJAR_DATA_DIR", data.path())
-            .assert().success();
+            .assert()
+            .success();
     }
     // has-session fails so new-session created, but attach fails
     let shim_dir = make_tmux_shim(1, 1, 0);
-    Command::cargo_bin("belljar").unwrap()
+    Command::cargo_bin("belljar")
+        .unwrap()
         .arg("control-center")
         .env("BELLJAR_DATA_DIR", data.path())
-        .env("PATH", prepend_path(&shim_dir.path().to_path_buf()))
+        .env("PATH", prepend_path(shim_dir.path()))
         .assert()
         .success()
         .stderr(predicate::str::contains("failed to attach control center"));

--- a/app/tests/cli_unknowns.rs
+++ b/app/tests/cli_unknowns.rs
@@ -1,4 +1,3 @@
-use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
@@ -6,8 +5,9 @@ use tempfile::TempDir;
 #[test]
 fn rm_unknown_session() {
     let data = TempDir::new().unwrap();
-    Command::cargo_bin("belljar").unwrap()
-        .args(["rm", "nope"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["rm", "nope"])
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
         .success()
@@ -17,8 +17,9 @@ fn rm_unknown_session() {
 #[test]
 fn open_unknown_session() {
     let data = TempDir::new().unwrap();
-    Command::cargo_bin("belljar").unwrap()
-        .args(["open", "nope"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["open", "nope"])
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
         .success()
@@ -28,8 +29,9 @@ fn open_unknown_session() {
 #[test]
 fn send_unknown_session() {
     let data = TempDir::new().unwrap();
-    Command::cargo_bin("belljar").unwrap()
-        .args(["send", "nope", "echo"]) 
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["send", "nope", "echo"])
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
         .success()

--- a/app/tests/cli_worktree_fail.rs
+++ b/app/tests/cli_worktree_fail.rs
@@ -1,12 +1,11 @@
-use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
+use std::path::Path;
 use tempfile::TempDir;
 
-fn prepend_path(dir: &PathBuf) -> String {
+fn prepend_path(dir: &Path) -> String {
     let old = std::env::var("PATH").unwrap_or_default();
     format!("{}:{}", dir.display(), old)
 }
@@ -25,12 +24,13 @@ fn worktree_setup_failure_is_warned() {
     perm.set_mode(0o755);
     fs::set_permissions(&git, perm).unwrap();
 
-    Command::cargo_bin("belljar").unwrap()
-        .args(["start", "s1", "--path"]).arg(repo.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["start", "s1", "--path"])
+        .arg(repo.path())
         .env("BELLJAR_DATA_DIR", data.path())
-        .env("PATH", prepend_path(&shim_dir.path().to_path_buf()))
+        .env("PATH", prepend_path(shim_dir.path()))
         .assert()
         .success()
         .stderr(predicate::str::contains("worktree setup failed"));
 }
-

--- a/app/tests/tmux_cli.rs
+++ b/app/tests/tmux_cli.rs
@@ -16,8 +16,20 @@ fn init_git_repo() -> tempfile::TempDir {
         .status()
         .unwrap()
         .success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.email","ci@example.com"]).status().unwrap().success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.name","CI"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.email", "ci@example.com"])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.name", "CI"])
+        .status()
+        .unwrap()
+        .success());
     std::fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")
         .arg("-C")

--- a/app/tests/tmux_cli.rs
+++ b/app/tests/tmux_cli.rs
@@ -16,6 +16,8 @@ fn init_git_repo() -> tempfile::TempDir {
         .status()
         .unwrap()
         .success());
+    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.email","ci@example.com"]).status().unwrap().success());
+    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.name","CI"]).status().unwrap().success());
     std::fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")
         .arg("-C")

--- a/core/tests/compose_errors.rs
+++ b/core/tests/compose_errors.rs
@@ -13,7 +13,11 @@ fn compose_up_error() {
     par_core::set_data_dir_override_for_testing(data.path());
     let repo = TempDir::new().unwrap();
     // root compose present
-    fs::write(repo.path().join("docker-compose.yml"), "version: '3.9'\nservices: {}\n").unwrap();
+    fs::write(
+        repo.path().join("docker-compose.yml"),
+        "version: '3.9'\nservices: {}\n",
+    )
+    .unwrap();
 
     // docker shim fails
     let shim_dir = TempDir::new().unwrap();
@@ -25,7 +29,10 @@ fn compose_up_error() {
     std::env::set_var("PATH", prepend_path(shim_dir.path()));
 
     let s = par_core::create_session("t", repo.path(), None, vec![]).unwrap();
-    match par_core::compose::up(&s) { Err(par_core::CoreError::Compose(_)) => {}, _ => panic!("expected compose error") }
+    match par_core::compose::up(&s) {
+        Err(par_core::CoreError::Compose(_)) => {}
+        _ => panic!("expected compose error"),
+    }
 }
 
 #[test]
@@ -34,7 +41,11 @@ fn compose_down_error() {
     par_core::set_data_dir_override_for_testing(data.path());
     let repo = TempDir::new().unwrap();
     // root compose present
-    fs::write(repo.path().join("docker-compose.yml"), "version: '3.9'\nservices: {}\n").unwrap();
+    fs::write(
+        repo.path().join("docker-compose.yml"),
+        "version: '3.9'\nservices: {}\n",
+    )
+    .unwrap();
 
     // docker shim fails
     let shim_dir = TempDir::new().unwrap();
@@ -46,5 +57,8 @@ fn compose_down_error() {
     std::env::set_var("PATH", prepend_path(shim_dir.path()));
 
     let s = par_core::create_session("t", repo.path(), None, vec![]).unwrap();
-    match par_core::compose::down(&s) { Err(par_core::CoreError::Compose(_)) => {}, _ => panic!("expected compose error") }
+    match par_core::compose::down(&s) {
+        Err(par_core::CoreError::Compose(_)) => {}
+        _ => panic!("expected compose error"),
+    }
 }

--- a/core/tests/core_negative.rs
+++ b/core/tests/core_negative.rs
@@ -7,9 +7,15 @@ fn compose_up_down_no_files() {
     let repo = TempDir::new().unwrap();
     let s = par_core::create_session("t", repo.path(), None, vec![]).unwrap();
     let up = par_core::compose::up(&s).unwrap_err();
-    match up { par_core::CoreError::NoComposeFiles => {}, _ => panic!("unexpected error") }
+    match up {
+        par_core::CoreError::NoComposeFiles => {}
+        _ => panic!("unexpected error"),
+    }
     let down = par_core::compose::down(&s).unwrap_err();
-    match down { par_core::CoreError::NoComposeFiles => {}, _ => panic!("unexpected error") }
+    match down {
+        par_core::CoreError::NoComposeFiles => {}
+        _ => panic!("unexpected error"),
+    }
 }
 
 #[test]
@@ -29,7 +35,9 @@ fn tmux_not_found() {
         created_at: "now".into(),
     };
     let e = par_core::tmux::ensure_session(&s).unwrap_err();
-    match e { par_core::CoreError::TmuxNotFound => {}, _ => panic!("unexpected error: {e}") }
+    match e {
+        par_core::CoreError::TmuxNotFound => {}
+        _ => panic!("unexpected error: {e}"),
+    }
     std::env::set_var("PATH", old);
 }
-

--- a/core/tests/tmux_errors.rs
+++ b/core/tests/tmux_errors.rs
@@ -37,9 +37,14 @@ fn new_window_and_select_layout_errors() {
 
     // new_window should error
     let e = par_core::tmux::new_window(&s.tmux_session, "w1", &s.repo_path).unwrap_err();
-    match e { par_core::CoreError::Tmux(_) => {}, _ => panic!("unexpected error") }
+    match e {
+        par_core::CoreError::Tmux(_) => {}
+        _ => panic!("unexpected error"),
+    }
     // select_layout should error
     let e = par_core::tmux::select_layout(&s.tmux_session, "tiled").unwrap_err();
-    match e { par_core::CoreError::Tmux(_) => {}, _ => panic!("unexpected error") }
+    match e {
+        par_core::CoreError::Tmux(_) => {}
+        _ => panic!("unexpected error"),
+    }
 }
-

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,2 +1,1 @@
 // Support crate for integration tests
-

--- a/tests/tests/cli_smoke.rs
+++ b/tests/tests/cli_smoke.rs
@@ -16,6 +16,21 @@ fn init_git_repo() -> tempfile::TempDir {
         .status()
         .unwrap()
         .success());
+    // set identity for commit on CI
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.email", "ci@example.com"])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.name", "CI"])
+        .status()
+        .unwrap()
+        .success());
     std::fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")
         .arg("-C")

--- a/tests/tests/cli_smoke.rs
+++ b/tests/tests/cli_smoke.rs
@@ -1,4 +1,6 @@
 #![cfg(not(coverage))]
+#![allow(unexpected_cfgs)]
+#![cfg(not(coverage))]
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use std::process::Command;
@@ -7,10 +9,28 @@ use tempfile::TempDir;
 fn init_git_repo() -> tempfile::TempDir {
     let td = TempDir::new().unwrap();
     let repo = td.path();
-    assert!(Command::new("git").arg("-C").arg(repo).arg("init").status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .arg("init")
+        .status()
+        .unwrap()
+        .success());
     std::fs::write(repo.join("README.md"), "init\n").unwrap();
-    assert!(Command::new("git").arg("-C").arg(repo).args(["add", "."]).status().unwrap().success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["commit", "-m", "init"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["add", "."])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["commit", "-m", "init"])
+        .status()
+        .unwrap()
+        .success());
     td
 }
 
@@ -20,15 +40,18 @@ fn cli_ls_start_rm_cycle() {
     let repo = init_git_repo();
 
     // start
-    Command::cargo_bin("belljar").unwrap()
-        .args(["start", "s1", "--path"]) .arg(repo.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["start", "s1", "--path"])
+        .arg(repo.path())
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
         .success()
         .stdout(predicate::str::contains("created session: s1"));
 
     // ls contains s1
-    Command::cargo_bin("belljar").unwrap()
+    Command::cargo_bin("belljar")
+        .unwrap()
         .arg("ls")
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
@@ -36,7 +59,8 @@ fn cli_ls_start_rm_cycle() {
         .stdout(predicate::str::contains("s1\t"));
 
     // rm s1
-    Command::cargo_bin("belljar").unwrap()
+    Command::cargo_bin("belljar")
+        .unwrap()
         .args(["rm", "s1"])
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
@@ -44,7 +68,8 @@ fn cli_ls_start_rm_cycle() {
         .stdout(predicate::str::contains("removed s1"));
 
     // ls should not include s1 anymore
-    Command::cargo_bin("belljar").unwrap()
+    Command::cargo_bin("belljar")
+        .unwrap()
         .arg("ls")
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
@@ -58,11 +83,19 @@ fn cli_checkout_creates_session() {
     let repo = init_git_repo();
 
     // create a branch to checkout
-    assert!(Command::new("git").arg("-C").arg(repo.path()).args(["checkout", "-b", "fx"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo.path())
+        .args(["checkout", "-b", "fx"])
+        .status()
+        .unwrap()
+        .success());
 
     // checkout
-    Command::cargo_bin("belljar").unwrap()
-        .args(["checkout", "fx", "--path"]) .arg(repo.path())
+    Command::cargo_bin("belljar")
+        .unwrap()
+        .args(["checkout", "fx", "--path"])
+        .arg(repo.path())
         .env("BELLJAR_DATA_DIR", data.path())
         .assert()
         .success()

--- a/tests/tests/compose_discovery.rs
+++ b/tests/tests/compose_discovery.rs
@@ -5,7 +5,11 @@ fn compose_discovery_prefers_belljar_dir() {
     let td = TempDir::new().unwrap();
     let repo = td.path();
     // root compose present
-    std::fs::write(repo.join("docker-compose.yml"), "version: '3.9'\nservices: {}\n").unwrap();
+    std::fs::write(
+        repo.join("docker-compose.yml"),
+        "version: '3.9'\nservices: {}\n",
+    )
+    .unwrap();
     // .belljar/compose present with two files
     let bj_dir = repo.join(".belljar/compose");
     std::fs::create_dir_all(&bj_dir).unwrap();
@@ -14,8 +18,10 @@ fn compose_discovery_prefers_belljar_dir() {
 
     let files = par_core::compose::discover_files_for_repo(repo);
     // Should include only the two files from .belljar/compose, sorted
-    let mut names: Vec<_> = files.iter().map(|p| p.file_name().unwrap().to_string_lossy().to_string()).collect();
+    let mut names: Vec<_> = files
+        .iter()
+        .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
     names.sort();
     assert_eq!(names, vec!["a.yml", "b.yaml"]);
 }
-

--- a/tests/tests/compose_discovery_root.rs
+++ b/tests/tests/compose_discovery_root.rs
@@ -5,12 +5,18 @@ fn compose_discovery_falls_back_to_root() {
     let td = TempDir::new().unwrap();
     let repo = td.path();
     // root compose present
-    std::fs::write(repo.join("docker-compose.yaml"), "version: '3.9'\nservices: {}\n").unwrap();
+    std::fs::write(
+        repo.join("docker-compose.yaml"),
+        "version: '3.9'\nservices: {}\n",
+    )
+    .unwrap();
     // .belljar/compose exists but is empty
     std::fs::create_dir_all(repo.join(".belljar/compose")).unwrap();
 
     let files = par_core::compose::discover_files_for_repo(repo);
-    let names: Vec<_> = files.iter().map(|p| p.file_name().unwrap().to_string_lossy().to_string()).collect();
+    let names: Vec<_> = files
+        .iter()
+        .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
     assert_eq!(names, vec!["docker-compose.yaml"]);
 }
-

--- a/tests/tests/core_smoke.rs
+++ b/tests/tests/core_smoke.rs
@@ -2,4 +2,3 @@
 fn core_version_is_nonempty() {
     assert!(!par_core::version().is_empty());
 }
-

--- a/tests/tests/git_worktree.rs
+++ b/tests/tests/git_worktree.rs
@@ -18,6 +18,8 @@ fn git_worktree_creates_dir() {
         .status()
         .unwrap()
         .success());
+    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.email","ci@example.com"]).status().unwrap().success());
+    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.name","CI"]).status().unwrap().success());
     // create initial commit
     std::fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")

--- a/tests/tests/git_worktree.rs
+++ b/tests/tests/git_worktree.rs
@@ -4,19 +4,39 @@ use tempfile::TempDir;
 #[test]
 fn git_worktree_creates_dir() {
     // Skip if git not available
-    if Command::new("git").arg("--version").output().is_err() { return; }
+    if Command::new("git").arg("--version").output().is_err() {
+        return;
+    }
 
     let repo_td = TempDir::new().unwrap();
     let repo = repo_td.path();
     // init git repo
-    assert!(Command::new("git").arg("-C").arg(repo).arg("init").status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .arg("init")
+        .status()
+        .unwrap()
+        .success());
     // create initial commit
     std::fs::write(repo.join("README.md"), "init\n").unwrap();
-    assert!(Command::new("git").arg("-C").arg(repo).args(["add", "."]).status().unwrap().success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["commit", "-m", "init"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["add", "."])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["commit", "-m", "init"])
+        .status()
+        .unwrap()
+        .success());
 
     // ensure worktree
-    let wt = par_core::git::ensure_worktree(repo, "wt-test", &Some("wt-test".into())).expect("worktree");
+    let wt =
+        par_core::git::ensure_worktree(repo, "wt-test", &Some("wt-test".into())).expect("worktree");
     assert!(wt.exists(), "worktree path should exist");
 }
-

--- a/tests/tests/git_worktree.rs
+++ b/tests/tests/git_worktree.rs
@@ -18,8 +18,20 @@ fn git_worktree_creates_dir() {
         .status()
         .unwrap()
         .success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.email","ci@example.com"]).status().unwrap().success());
-    assert!(Command::new("git").arg("-C").arg(repo).args(["config","user.name","CI"]).status().unwrap().success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.email", "ci@example.com"])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["config", "user.name", "CI"])
+        .status()
+        .unwrap()
+        .success());
     // create initial commit
     std::fs::write(repo.join("README.md"), "init\n").unwrap();
     assert!(Command::new("git")

--- a/tests/tests/registry_prop.rs
+++ b/tests/tests/registry_prop.rs
@@ -21,7 +21,7 @@ proptest! {
         let mut seen = HashSet::new();
         for (i, label) in labels.iter().enumerate() {
             if seen.insert(label.clone()) {
-                let branch = if i % 2 == 0 { Some(format!("feat_{}", i)) } else { None };
+                let branch = if i % 2 == 0 { Some(format!("feat_{i}")) } else { None };
                 let s = par_core::create_session(label, repo, branch, vec![]).expect("create session");
                 assert_eq!(&s.label, label);
             }

--- a/tests/tests/tmux_helpers.rs
+++ b/tests/tests/tmux_helpers.rs
@@ -1,9 +1,9 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
+use std::path::Path;
 use tempfile::TempDir;
 
-fn prepend_path(dir: &PathBuf) -> String {
+fn prepend_path(dir: &Path) -> String {
     let old = std::env::var("PATH").unwrap_or_default();
     format!("{}:{}", dir.display(), old)
 }
@@ -19,7 +19,7 @@ fn tmux_helpers_call_binary() {
     let mut perm = fs::metadata(&shim).unwrap().permissions();
     perm.set_mode(0o755);
     fs::set_permissions(&shim, perm).unwrap();
-    std::env::set_var("PATH", prepend_path(&shim_dir.path().to_path_buf()));
+    std::env::set_var("PATH", prepend_path(shim_dir.path()));
 
     // Minimal session
     let s = par_core::Session {


### PR DESCRIPTION
- Enforce formatting and clippy clean locally before PRs (AGENTS.md).
- cargo fmt --all applied; cargo clippy --all-targets --all-features -D warnings clean.
- No functional changes. CI already checks fmt/clippy; this ensures local discipline.