### PR TITLE
docs(Phase 6): README workspace usage + spec, annotate PRs with PLAN stage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,8 @@
 - Keep changes scoped; update docs/examples when interfaces or flags change.
 - Before opening a PR: ensure formatting and linting are clean.
   - Format: `cargo fmt --all` (no diffs).
-  - Lint: `cargo clippy --all-targets --all-features -D warnings` (zero warnings).
+  - Lint: `cargo clippy --all-targets --all-features -- -D warnings` (zero warnings).
+  - Annotate PLAN stage in PR title or body (e.g., `Phase 6 — Docs polish`) and list PLAN items addressed.
 
 ## Plan-Driven Workflow
 - Always work from `PLAN.md` as the single source of truth.

--- a/PLAN.md
+++ b/PLAN.md
@@ -71,12 +71,12 @@ Deliverables:
 Deliverables:
 - Green CI for non-Docker paths; documented local flow for Docker tests.
 
-## Phase 6 — UX Polish & Docs — [PENDING]
-1. Human-friendly logs (task prefixes, colors, timing) and `--json` for machine parsing.
-2. Errors with suggestions; `par-rs doctor` for environment diagnostics.
+## Phase 6 — UX Polish & Docs — [IN PROGRESS]
+1. Human-friendly logs (task prefixes, colors, timing) and `--json` for machine parsing. [PENDING]
+2. Errors with suggestions; `belljar doctor` for environment diagnostics. [PENDING]
 3. Documentation:
-   - Quickstart, config reference, examples with popular stacks.
-   - How isolation works; performance tips; cleanup commands.
+   - Quickstart, config reference, examples with popular stacks. [IN PROGRESS]
+   - How isolation works; performance tips; cleanup commands. [PENDING]
 
 Deliverables:
 - `README.md` and `docs/` with examples and troubleshooting.
@@ -93,7 +93,7 @@ M2: Registry + compose discovery + up/down — DONE
 M3: tmux open/send for sessions — DONE
 M4: Repo worktree/branch creation + checkout — DONE
 M5: Tests + CI (coverage) — IN PROGRESS
-M6: Docs + examples + 0.1 release — PENDING
+M6: Docs + examples + 0.1 release — IN PROGRESS
 M7: Dogfood belljar to develop itself — PENDING
 
 ## Open Questions / To Validate

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ A Rust CLI inspired by coplane/par for managing development sessions and worktre
 - Open and send commands (tmux):
   - `cargo run -p par-cli -- open my-feature`
   - `cargo run -p par-cli -- send my-feature "make test"`
+- Workspaces (multi-repo context):
+  - List: `cargo run -p par-cli -- workspace ls`
+  - Create: `cargo run -p par-cli -- workspace start dev-ws --path . --repos frontend,backend --open`
+  - Open: `cargo run -p par-cli -- workspace open dev-ws`
+  - Remove: `cargo run -p par-cli -- workspace rm dev-ws`
 - List and remove sessions:
   - `cargo run -p par-cli -- ls`
   - `cargo run -p par-cli -- rm my-feature` or `rm all`
@@ -26,3 +31,4 @@ Notes
 - Compose discovery is repo-owned: belljar never ships service templates.
 - If tmux is not installed, open prints a fallback path; send will fail gracefully.
 - Worktrees are stored under `.belljar/worktrees/` and are ignored by git.
+- Workspaces are recorded in the registry and open a dedicated tmux session (named `ws-<label>`).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -12,9 +12,11 @@
 - `belljar rm <label|all>`
 - `belljar send <label|all> <command...>`
 - `belljar control-center`
-- `belljar workspace <subcmd>` where subcmds include:
+- `belljar workspace <subcmd>`: workspace (multi-repo) management
+  - `ls` — list workspaces
   - `start <label> [--path <root>] [--repos r1,r2] [--open]`
-  - `code <label>` | `open <label>` | `rm <label>` | `ls`
+  - `open <label>` — ensure/attach tmux session
+  - `rm <label>` — remove workspace by label or id
 
 Notes
 - We will initially implement sessions: `start`, `ls`, `open`, `rm` and `send` with minimal functionality, then add `checkout`, `control-center`, and `workspace`.
@@ -49,3 +51,10 @@ Notes
 - Windows support.
 - Complex PR checkout flows.
 - Multi-repo workspace orchestration.
+## Workspace Model
+- id: UUID4
+- label: unique string
+- root_path: absolute path to workspace root
+- repos: absolute paths to member repos (optional list)
+- tmux_session: name used for tmux (e.g., `ws-<label>`)
+- created_at: RFC3339 timestamp


### PR DESCRIPTION
Phase 6 — UX Polish & Docs (in progress)

- README: adds workspace command usage (ls/start/open/rm) and notes on workspace tmux session naming.
- docs/spec.md: documents workspace CLI surface and the Workspace model (label/root_path/repos/tmux_session/created_at).
- AGENTS.md: requires annotating PRs with the PLAN stage and lists items addressed; fixes clippy invocation to `-- -D warnings`.
- PLAN.md: marks Phase 6 as In Progress and updates milestones accordingly.

Coverage
- Current total coverage: 75.7% (454/600) via `./scripts/coverage.sh`.

Next
- Add focused tests for workspace flows to raise coverage, and polish workspace UX (e.g., one tmux window per repo).
