### PR TITLE
refactor(core,cli,docs): finalize par->belljar rename

### DIFF
--- a/.belljar/pr.md
+++ b/.belljar/pr.md
@@ -1,0 +1,22 @@
+### Summary
+
+- Finalize `par` -> `belljar` rename across core, CLI, and docs.
+- Core: change data dir vendor/app to `belljar` and compose project prefix to `belljar_<shortid>`.
+- CLI: version output now prints `belljar <cli> (core <ver>)`.
+- Docs: update spec and plan to reflect new compose project prefix and registry path.
+
+### Rationale
+
+Maintains consistent naming and user-facing identifiers after the refactor. Using `belljar_<shortid>` for compose project names avoids collisions and aligns with the tool’s name. Data directory under `~/.local/share/belljar` is clearer and decoupled from historical `par-rs`.
+
+### Notes
+
+- All tests pass locally: `cargo test` (no Docker required for these tests).
+- Lint and format are clean: `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`.
+- No behavioral changes aside from identifiers and version string.
+
+### PLAN
+
+- Phase 5 — Tests & CI: keep CI wiring PENDING.
+- Phase 6 — Docs Polish: adjusted spec/plan strings accordingly.
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,10 +95,36 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "belljar-core",
  "clap",
  "dirs",
- "par-core",
  "predicates",
+ "tempfile",
+]
+
+[[package]]
+name = "belljar-core"
+version = "0.1.0"
+dependencies = [
+ "directories",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "time",
+ "uuid",
+ "which",
+]
+
+[[package]]
+name = "belljar-test"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "belljar-core",
+ "predicates",
+ "proptest",
  "tempfile",
 ]
 
@@ -424,32 +450,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "par-core"
-version = "0.1.0"
-dependencies = [
- "directories",
- "once_cell",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror",
- "time",
- "uuid",
- "which",
-]
-
-[[package]]
-name = "par-tests"
-version = "0.1.0"
-dependencies = [
- "assert_cmd",
- "par-core",
- "predicates",
- "proptest",
- "tempfile",
-]
 
 [[package]]
 name = "powerfmt"

--- a/Dockerfile.ai
+++ b/Dockerfile.ai
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.4
+# Helper container for using OpenAI Codex-like workflows
+FROM dockerfile:Dockerfile.dev
+
+WORKDIR /workspace
+
+ENV PIP_NO_CACHE_DIR=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip git curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Libraries commonly used to interface with OpenAI APIs
+RUN pip install --no-cache-dir openai tiktoken
+
+# Set your credentials at runtime or via compose env_file
+# ENV OPENAI_API_KEY=...
+
+CMD ["bash"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM rust:1-bookworm AS base
+
+WORKDIR /workspace
+
+# Common native deps (adjust as needed)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential pkg-config libssl-dev ca-certificates curl git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Optionally pre-build deps for faster iterative builds
+# COPY Cargo.toml Cargo.lock ./
+# RUN mkdir -p src && echo "fn main(){}" > src/main.rs \
+#     && cargo build --release \
+#     && rm -rf src
+
+# Bring in your code
+COPY . .
+
+# Build command example:
+# RUN cargo build --release
+
+CMD ["bash"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -83,7 +83,7 @@ Deliverables:
 - `README.md` and `docs/` with examples and troubleshooting.
 
 ## Implementation Notes
-- Compose project isolation: always pass `-p parrs_<shortid>` and set `COMPOSE_PROJECT_NAME`.
+- Compose project isolation: always pass `-p belljar_<shortid>` and set `COMPOSE_PROJECT_NAME`.
 - Resource limits: expose `--cpus/--memory` per service via compose overrides.
 - Security: avoid mounting host docker.sock into containers; long-running services live only within the session project.
 - Extensibility: service templates as modular YAML snippets in `assets/compose/`.

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-par-core = { path = "../core" }
+belljar-core = { path = "../core" }
 dirs = "5.0"
 
 [dev-dependencies]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -131,8 +131,9 @@ fn main() -> anyhow::Result<()> {
         } => {
             let repo = resolve_repo_path(path.as_deref())?;
             let label = label.unwrap_or_else(|| target.clone());
-            let mut session = belljar_core::create_session(&label, &repo, Some(target.clone()), vec![])
-                .map_err(|e| anyhow::anyhow!("create session failed: {e}"))?;
+            let mut session =
+                belljar_core::create_session(&label, &repo, Some(target.clone()), vec![])
+                    .map_err(|e| anyhow::anyhow!("create session failed: {e}"))?;
             if belljar_core::git::is_git_repo(&repo) {
                 match belljar_core::git::ensure_worktree(&repo, &label, &Some(target.clone())) {
                     Ok(wt) => {
@@ -233,7 +234,8 @@ fn main() -> anyhow::Result<()> {
                         for s in reg.sessions {
                             match belljar_core::tmux::ensure_session(&s) {
                                 Ok(()) => {
-                                    if let Err(e) = belljar_core::tmux::send_keys(&s.tmux_session, &cmd)
+                                    if let Err(e) =
+                                        belljar_core::tmux::send_keys(&s.tmux_session, &cmd)
                                     {
                                         eprintln!("send to {} failed: {e}", s.label);
                                     }
@@ -273,9 +275,11 @@ fn main() -> anyhow::Result<()> {
                             Ok(()) => {
                                 for s in reg.sessions {
                                     // Try to create a window per session label
-                                    if let Err(e) =
-                                        belljar_core::tmux::new_window(cc_name, &s.label, &s.repo_path)
-                                    {
+                                    if let Err(e) = belljar_core::tmux::new_window(
+                                        cc_name,
+                                        &s.label,
+                                        &s.repo_path,
+                                    ) {
                                         eprintln!("failed to create window for {}: {e}", s.label);
                                     }
                                 }
@@ -343,7 +347,9 @@ fn main() -> anyhow::Result<()> {
                             .file_name()
                             .map(|s| s.to_string_lossy().to_string())
                             .unwrap_or_else(|| repo.display().to_string());
-                        if let Err(e) = belljar_core::tmux::new_window(&ws.tmux_session, &name, repo) {
+                        if let Err(e) =
+                            belljar_core::tmux::new_window(&ws.tmux_session, &name, repo)
+                        {
                             eprintln!("failed to create window for {name}: {e}");
                         }
                     }
@@ -363,7 +369,7 @@ fn main() -> anyhow::Result<()> {
         },
         Commands::Version => {
             println!(
-                "par {} (core {})",
+                "belljar {} (core {})",
                 env!("CARGO_PKG_VERSION"),
                 belljar_core::version()
             );
@@ -406,8 +412,6 @@ fn run_wizard() -> anyhow::Result<()> {
     let ai = prompt_ai()?;
 
     let cwd = std::env::current_dir()?;
-    // For now, write scaffolded Dockerfiles at the project root to match expectations
-    // in our CLI tests. Users can move them under .belljar/compose later if desired.
     println!("\nScaffolding in {}", cwd.display());
 
     // Language-specific Dockerfile for development

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "par-core"
+name = "belljar-core"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
-description = "Core library for par-rs (config, session, compose, runner)"
+description = "Core library for belljar (config, session, compose, runner)"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,4 @@
-//! par-core: internal library for par-rs
+//! belljar-core: internal library for belljar (config, session, compose, runner)
 
 use directories::ProjectDirs;
 use once_cell::sync::Lazy;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -80,7 +80,7 @@ fn data_dir() -> Result<PathBuf, CoreError> {
         fs::create_dir_all(&p)?;
         return Ok(p);
     }
-    let dirs = ProjectDirs::from("dev", "par-rs", "par-rs").ok_or(CoreError::NoRegistryPath)?;
+    let dirs = ProjectDirs::from("dev", "belljar", "belljar").ok_or(CoreError::NoRegistryPath)?;
     let dir = dirs.data_dir().to_path_buf();
     fs::create_dir_all(&dir)?;
     Ok(dir)
@@ -128,7 +128,7 @@ pub fn create_session(
 ) -> Result<Session, CoreError> {
     let mut reg = load_registry()?;
     let id = Uuid::new_v4().to_string();
-    let compose_project = format!("parrs_{}", &id[..8]);
+    let compose_project = format!("belljar_{}", &id[..8]);
     let tmux_session = label.to_string();
     let created_at = OffsetDateTime::now_utc()
         .format(&time::format_description::well_known::Rfc3339)

--- a/core/tests/compose_errors.rs
+++ b/core/tests/compose_errors.rs
@@ -21,7 +21,7 @@ fn compose_up_error() {
     let orig_path = std::env::var("PATH").unwrap_or_default();
 
     let data = TempDir::new().unwrap();
-    par_core::set_data_dir_override_for_testing(data.path());
+    belljar_core::set_data_dir_override_for_testing(data.path());
     let repo = TempDir::new().unwrap();
     // root compose present
     fs::write(
@@ -31,7 +31,7 @@ fn compose_up_error() {
     .unwrap();
 
     // create session with real docker
-    let s = par_core::create_session("t", repo.path(), None, vec![]).unwrap();
+    let s = belljar_core::create_session("t", repo.path(), None, vec![]).unwrap();
 
     // docker shim fails
     let shim_dir = TempDir::new().unwrap();
@@ -42,8 +42,8 @@ fn compose_up_error() {
     fs::set_permissions(&shim, perm).unwrap();
     std::env::set_var("PATH", prepend_path(shim_dir.path()));
 
-    match par_core::compose::up(&s) {
-        Err(par_core::CoreError::Compose(_)) => {}
+    match belljar_core::compose::up(&s) {
+        Err(belljar_core::CoreError::Compose(_)) => {}
         _ => panic!("expected compose error"),
     }
 
@@ -61,7 +61,7 @@ fn compose_down_error() {
     let orig_path = std::env::var("PATH").unwrap_or_default();
 
     let data = TempDir::new().unwrap();
-    par_core::set_data_dir_override_for_testing(data.path());
+    belljar_core::set_data_dir_override_for_testing(data.path());
     let repo = TempDir::new().unwrap();
     // root compose present
     fs::write(
@@ -71,7 +71,7 @@ fn compose_down_error() {
     .unwrap();
 
     // create session with real docker
-    let s = par_core::create_session("t", repo.path(), None, vec![]).unwrap();
+    let s = belljar_core::create_session("t", repo.path(), None, vec![]).unwrap();
 
     // docker shim fails
     let shim_dir = TempDir::new().unwrap();
@@ -82,8 +82,8 @@ fn compose_down_error() {
     fs::set_permissions(&shim, perm).unwrap();
     std::env::set_var("PATH", prepend_path(shim_dir.path()));
 
-    match par_core::compose::down(&s) {
-        Err(par_core::CoreError::Compose(_)) => {}
+    match belljar_core::compose::down(&s) {
+        Err(belljar_core::CoreError::Compose(_)) => {}
         _ => panic!("expected compose error"),
     }
 

--- a/core/tests/core_negative.rs
+++ b/core/tests/core_negative.rs
@@ -3,17 +3,17 @@ use tempfile::TempDir;
 #[test]
 fn compose_up_down_no_files() {
     let data = TempDir::new().unwrap();
-    par_core::set_data_dir_override_for_testing(data.path());
+    belljar_core::set_data_dir_override_for_testing(data.path());
     let repo = TempDir::new().unwrap();
-    let s = par_core::create_session("t", repo.path(), None, vec![]).unwrap();
-    let up = par_core::compose::up(&s).unwrap_err();
+    let s = belljar_core::create_session("t", repo.path(), None, vec![]).unwrap();
+    let up = belljar_core::compose::up(&s).unwrap_err();
     match up {
-        par_core::CoreError::NoComposeFiles => {}
+        belljar_core::CoreError::NoComposeFiles => {}
         _ => panic!("unexpected error"),
     }
-    let down = par_core::compose::down(&s).unwrap_err();
+    let down = belljar_core::compose::down(&s).unwrap_err();
     match down {
-        par_core::CoreError::NoComposeFiles => {}
+        belljar_core::CoreError::NoComposeFiles => {}
         _ => panic!("unexpected error"),
     }
 }
@@ -23,7 +23,7 @@ fn tmux_not_found() {
     // Temporarily clear PATH so which("tmux") fails
     let old = std::env::var("PATH").unwrap_or_default();
     std::env::set_var("PATH", "/nonexistent");
-    let s = par_core::Session {
+    let s = belljar_core::Session {
         id: "id".into(),
         label: "lab".into(),
         repo_path: std::env::current_dir().unwrap(),
@@ -34,9 +34,9 @@ fn tmux_not_found() {
         tmux_session: "sess".into(),
         created_at: "now".into(),
     };
-    let e = par_core::tmux::ensure_session(&s).unwrap_err();
+    let e = belljar_core::tmux::ensure_session(&s).unwrap_err();
     match e {
-        par_core::CoreError::TmuxNotFound => {}
+        belljar_core::CoreError::TmuxNotFound => {}
         _ => panic!("unexpected error: {e}"),
     }
     std::env::set_var("PATH", old);

--- a/core/tests/tmux_errors.rs
+++ b/core/tests/tmux_errors.rs
@@ -23,7 +23,7 @@ fn new_window_and_select_layout_errors() {
     let shim_dir = make_tmux_shim();
     std::env::set_var("PATH", prepend_path(shim_dir.path()));
 
-    let s = par_core::Session {
+    let s = belljar_core::Session {
         id: "id".into(),
         label: "lab".into(),
         repo_path: std::env::current_dir().unwrap(),
@@ -36,15 +36,15 @@ fn new_window_and_select_layout_errors() {
     };
 
     // new_window should error
-    let e = par_core::tmux::new_window(&s.tmux_session, "w1", &s.repo_path).unwrap_err();
+    let e = belljar_core::tmux::new_window(&s.tmux_session, "w1", &s.repo_path).unwrap_err();
     match e {
-        par_core::CoreError::Tmux(_) => {}
+        belljar_core::CoreError::Tmux(_) => {}
         _ => panic!("unexpected error"),
     }
     // select_layout should error
-    let e = par_core::tmux::select_layout(&s.tmux_session, "tiled").unwrap_err();
+    let e = belljar_core::tmux::select_layout(&s.tmux_session, "tiled").unwrap_err();
     match e {
-        par_core::CoreError::Tmux(_) => {}
+        belljar_core::CoreError::Tmux(_) => {}
         _ => panic!("unexpected error"),
     }
 }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -30,12 +30,12 @@ Notes
 - repo_path: absolute path to git repository.
 - branch: branch/PR info.
 - worktree_path: path to created worktree.
-- compose_project: `parrs_<shortid>`; stored to allow cleanup.
+- compose_project: `belljar_<shortid>`; stored to allow cleanup.
 - services: list of enabled services.
 - tmux_session: tmux session name (derived from label).
 
 ## Storage
-- Registry at `~/.local/share/par-rs/registry.json` (or platform-appropriate dir) tracks sessions and workspaces.
+- Registry at `~/.local/share/belljar/registry.json` (or platform-appropriate dir) tracks sessions and workspaces.
 
 ## Compose Isolation
 - Project-scoped: `docker compose -p <project> [-f files...] up -d`. Files come from the repo as described above.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "par-tests"
+name = "belljar-test"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
 [dev-dependencies]
-par-core = { path = "../core", features = ["testing"] }
+belljar-core = { path = "../core", features = ["testing"] }
 proptest = "1.5"
 tempfile = "3.10"
 assert_cmd = "2.0"

--- a/tests/tests/compose_discovery.rs
+++ b/tests/tests/compose_discovery.rs
@@ -16,7 +16,7 @@ fn compose_discovery_prefers_belljar_dir() {
     std::fs::write(bj_dir.join("a.yml"), "services: {}\n").unwrap();
     std::fs::write(bj_dir.join("b.yaml"), "services: {}\n").unwrap();
 
-    let files = par_core::compose::discover_files_for_repo(repo);
+    let files = belljar_core::compose::discover_files_for_repo(repo);
     // Should include only the two files from .belljar/compose, sorted
     let mut names: Vec<_> = files
         .iter()

--- a/tests/tests/compose_discovery_root.rs
+++ b/tests/tests/compose_discovery_root.rs
@@ -13,7 +13,7 @@ fn compose_discovery_falls_back_to_root() {
     // .belljar/compose exists but is empty
     std::fs::create_dir_all(repo.join(".belljar/compose")).unwrap();
 
-    let files = par_core::compose::discover_files_for_repo(repo);
+    let files = belljar_core::compose::discover_files_for_repo(repo);
     let names: Vec<_> = files
         .iter()
         .map(|p| p.file_name().unwrap().to_string_lossy().to_string())

--- a/tests/tests/compose_up_down.rs
+++ b/tests/tests/compose_up_down.rs
@@ -11,7 +11,7 @@ fn prepend_path(dir: &Path) -> String {
 #[test]
 fn compose_up_down_uses_repo_files_and_docker() {
     let data_td = TempDir::new().unwrap();
-    par_core::set_data_dir_override_for_testing(data_td.path());
+    belljar_core::set_data_dir_override_for_testing(data_td.path());
 
     // Prepare repo with .belljar/compose file
     let repo_td = TempDir::new().unwrap();
@@ -36,10 +36,10 @@ fn compose_up_down_uses_repo_files_and_docker() {
     std::env::set_var("PATH", prepend_path(shim_dir.path()));
 
     // Create a session
-    let s = par_core::create_session("t", repo, None, vec![]).unwrap();
+    let s = belljar_core::create_session("t", repo, None, vec![]).unwrap();
     // Up should succeed and call docker compose with -f pointing to our file
-    par_core::compose::up(&s).unwrap();
-    par_core::compose::down(&s).unwrap();
+    belljar_core::compose::up(&s).unwrap();
+    belljar_core::compose::down(&s).unwrap();
 
     let logged = fs::read_to_string(&log).unwrap();
     assert!(logged.contains("compose"));

--- a/tests/tests/core_smoke.rs
+++ b/tests/tests/core_smoke.rs
@@ -1,4 +1,4 @@
 #[test]
 fn core_version_is_nonempty() {
-    assert!(!par_core::version().is_empty());
+    assert!(!belljar_core::version().is_empty());
 }

--- a/tests/tests/git_worktree.rs
+++ b/tests/tests/git_worktree.rs
@@ -50,7 +50,7 @@ fn git_worktree_creates_dir() {
         .success());
 
     // ensure worktree
-    let wt =
-        par_core::git::ensure_worktree(repo, "wt-test", &Some("wt-test".into())).expect("worktree");
+    let wt = belljar_core::git::ensure_worktree(repo, "wt-test", &Some("wt-test".into()))
+        .expect("worktree");
     assert!(wt.exists(), "worktree path should exist");
 }

--- a/tests/tests/registry_prop.rs
+++ b/tests/tests/registry_prop.rs
@@ -3,7 +3,7 @@ use tempfile::TempDir;
 
 fn init_temp_data_dir() -> TempDir {
     let td = TempDir::new().expect("tempdir");
-    par_core::set_data_dir_override_for_testing(td.path());
+    belljar_core::set_data_dir_override_for_testing(td.path());
     td
 }
 
@@ -22,23 +22,23 @@ proptest! {
         for (i, label) in labels.iter().enumerate() {
             if seen.insert(label.clone()) {
                 let branch = if i % 2 == 0 { Some(format!("feat_{i}")) } else { None };
-                let s = par_core::create_session(label, repo, branch, vec![]).expect("create session");
+                let s = belljar_core::create_session(label, repo, branch, vec![]).expect("create session");
                 assert_eq!(&s.label, label);
             }
         }
 
-        let reg = par_core::load_registry().expect("load");
+        let reg = belljar_core::load_registry().expect("load");
         // uniqueness of labels in property is not guaranteed; dedup the input
         let set: HashSet<_> = labels.iter().cloned().collect();
         assert_eq!(reg.sessions.len(), set.len());
 
         // find and remove
         if let Some(first) = labels.first() {
-            let found = par_core::find_session(first).expect("find");
+            let found = belljar_core::find_session(first).expect("find");
             assert!(found.is_some());
-            let removed = par_core::remove_session(first).expect("remove");
+            let removed = belljar_core::remove_session(first).expect("remove");
             assert!(removed.is_some());
-            let found_again = par_core::find_session(first).expect("find");
+            let found_again = belljar_core::find_session(first).expect("find");
             assert!(found_again.is_none());
         }
     }

--- a/tests/tests/tmux_helpers.rs
+++ b/tests/tests/tmux_helpers.rs
@@ -22,7 +22,7 @@ fn tmux_helpers_call_binary() {
     std::env::set_var("PATH", prepend_path(shim_dir.path()));
 
     // Minimal session
-    let s = par_core::Session {
+    let s = belljar_core::Session {
         id: "id".into(),
         label: "lab".into(),
         repo_path: std::env::current_dir().unwrap(),
@@ -34,11 +34,11 @@ fn tmux_helpers_call_binary() {
         created_at: "now".into(),
     };
 
-    par_core::tmux::ensure_session(&s).unwrap();
-    par_core::tmux::new_window(&s.tmux_session, "w1", &s.repo_path).unwrap();
-    par_core::tmux::select_layout(&s.tmux_session, "tiled").unwrap();
+    belljar_core::tmux::ensure_session(&s).unwrap();
+    belljar_core::tmux::new_window(&s.tmux_session, "w1", &s.repo_path).unwrap();
+    belljar_core::tmux::select_layout(&s.tmux_session, "tiled").unwrap();
     // attach too
-    par_core::tmux::attach(&s.tmux_session).unwrap();
+    belljar_core::tmux::attach(&s.tmux_session).unwrap();
 
     let logged = fs::read_to_string(&log).unwrap();
     assert!(logged.contains("has-session"));

--- a/tests/tests/workspace_core.rs
+++ b/tests/tests/workspace_core.rs
@@ -2,7 +2,7 @@ use tempfile::TempDir;
 
 fn init_data() -> TempDir {
     let td = TempDir::new().unwrap();
-    par_core::set_data_dir_override_for_testing(td.path());
+    belljar_core::set_data_dir_override_for_testing(td.path());
     td
 }
 
@@ -10,7 +10,7 @@ fn init_data() -> TempDir {
 fn workspace_crud_roundtrip() {
     let _data = init_data();
     // list empty
-    assert!(par_core::list_workspaces().unwrap().is_empty());
+    assert!(belljar_core::list_workspaces().unwrap().is_empty());
 
     let root = TempDir::new().unwrap();
     let repos = vec![root.path().join("frontend"), root.path().join("backend")];
@@ -18,20 +18,20 @@ fn workspace_crud_roundtrip() {
     std::fs::create_dir_all(&repos[1]).unwrap();
 
     // create
-    let ws = par_core::create_workspace("dev-ws", root.path(), repos.clone()).unwrap();
+    let ws = belljar_core::create_workspace("dev-ws", root.path(), repos.clone()).unwrap();
     assert_eq!(ws.label, "dev-ws");
     assert!(ws.tmux_session.starts_with("ws-"));
 
     // list -> 1
-    let list = par_core::list_workspaces().unwrap();
+    let list = belljar_core::list_workspaces().unwrap();
     assert_eq!(list.len(), 1);
 
     // find by label
-    let found = par_core::find_workspace("dev-ws").unwrap();
+    let found = belljar_core::find_workspace("dev-ws").unwrap();
     assert!(found.is_some());
 
     // remove
-    let removed = par_core::remove_workspace("dev-ws").unwrap();
+    let removed = belljar_core::remove_workspace("dev-ws").unwrap();
     assert!(removed.is_some());
-    assert!(par_core::list_workspaces().unwrap().is_empty());
+    assert!(belljar_core::list_workspaces().unwrap().is_empty());
 }


### PR DESCRIPTION
### Summary

- Finalize `par` -> `belljar` rename across core, CLI, and docs.
- Core: change data dir vendor/app to `belljar` and compose project prefix to `belljar_<shortid>`.
- CLI: version output now prints `belljar <cli> (core <ver>)`.
- Docs: update spec and plan to reflect new compose project prefix and registry path.

### Rationale

Maintains consistent naming and user-facing identifiers after the refactor. Using `belljar_<shortid>` for compose project names avoids collisions and aligns with the tool’s name. Data directory under `~/.local/share/belljar` is clearer and decoupled from historical `par-rs`.

### Notes

- All tests pass locally: `cargo test` (no Docker required for these tests).
- Lint and format are clean: `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`.
- No behavioral changes aside from identifiers and version string.

### PLAN

- Phase 5 — Tests & CI: keep CI wiring PENDING.
- Phase 6 — Docs Polish: adjusted spec/plan strings accordingly.

