### PR TITLE
feat(cli): add  command for branch+session setup; docs: tmux popup bindings

### DIFF
--- a/.belljar/pr-new.md
+++ b/.belljar/pr-new.md
@@ -1,0 +1,24 @@
+### Summary
+
+- feat(cli): add `belljar new <label> [--from <base>] [--path <repo>]` to create a new branch from a base (default `main`), set up a worktree under `.belljar/worktrees/<label>`, provision compose, and focus the tmux session.
+- core: add `git::ensure_worktree_from` and `tmux::switch_client` helpers.
+- docs: README section with tmux popup bindings (Ctrl-b j) for quick session creation/focus.
+
+### Rationale
+
+Fast path to start a focused dev session: a single keystroke (tmux popup) to branch from `main`/`develop`, create a belljar session with isolated compose, and jump right into a tmux session.
+
+### Usage
+
+```bash
+belljar new my-feature            # from main
+belljar new my-fix --from develop # from a custom base
+```
+
+Tmux popup binding (Ctrl-b j): see README’s "Tmux Integration" for a command-prompt and display-popup variant.
+
+### Notes
+
+- If the session already exists, `belljar new` focuses it (switches client inside tmux; attaches outside tmux).
+- No Docker dependency for non-compose repos. Compose up/down remains best-effort.
+

--- a/README.md
+++ b/README.md
@@ -32,3 +32,29 @@ Notes
 - If tmux is not installed, open prints a fallback path; send will fail gracefully.
 - Worktrees are stored under `.belljar/worktrees/` and are ignored by git.
 - Workspaces are recorded in the registry and open a dedicated tmux session (named `ws-<label>`).
+
+## Tmux Integration (Popup + Quick Focus)
+
+Bind a popup to create/focus a belljar session and jump to it with `Ctrl-b j`.
+
+- Minimal prompt (uses tmux's command-prompt):
+
+```tmux
+# ~/.tmux.conf
+bind-key j command-prompt -p "New belljar session:" \
+  "run-shell 'belljar new %1 --path #{pane_current_path}'; switch-client -t %1"
+```
+
+- Popup window with inline prompt and log output:
+
+```tmux
+# ~/.tmux.conf
+bind-key j display-popup -E "sh -lc 'read -p \"New belljar session (base: main): \" name; \\
+  [ -z \"$name\" ] || belljar new \"$name\" --path #{pane_current_path} 2>&1 | sed -u \"s/^/[belljar] /\"; \\
+  [ -z \"$name\" ] || tmux switch-client -t \"$name\"'"
+```
+
+Notes
+- Inside tmux, `belljar new` switches the client to the session; outside tmux it attaches.
+- Change the base branch with `--from <branch>` if you don't want `main`.
+- Reload config: `tmux source-file ~/.tmux.conf`.


### PR DESCRIPTION
### Summary

- feat(cli): add `belljar new <label> [--from <base>] [--path <repo>]` to create a new branch from a base (default `main`), set up a worktree under `.belljar/worktrees/<label>`, provision compose, and focus the tmux session.
- core: add `git::ensure_worktree_from` and `tmux::switch_client` helpers.
- docs: README section with tmux popup bindings (Ctrl-b j) for quick session creation/focus.

### Rationale

Fast path to start a focused dev session: a single keystroke (tmux popup) to branch from `main`/`develop`, create a belljar session with isolated compose, and jump right into a tmux session.

### Usage

```bash
belljar new my-feature            # from main
belljar new my-fix --from develop # from a custom base
```

Tmux popup binding (Ctrl-b j): see README’s "Tmux Integration" for a command-prompt and display-popup variant.

### Notes

- If the session already exists, `belljar new` focuses it (switches client inside tmux; attaches outside tmux).
- No Docker dependency for non-compose repos. Compose up/down remains best-effort.

